### PR TITLE
Add deployment helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This repository contains a minimal example for generating a promotional video.
 
 Contents:
 - `cloudformation.yaml` – defines AWS infrastructure for storing generated videos.
+- `deploy.sh` – script that deploys the CloudFormation stack.
 - `.microagent/.openhands/microagent/promo-video-agent.md` – instructions for requesting credits and creating the promo video using Codex, VEO3, Docker and Playwright.
 
 No keys or personal data are present in this repository.
+
+## Deploying the infrastructure
+
+Run `./deploy.sh` to create the S3 bucket defined in `cloudformation.yaml`. An optional stack name may be supplied; it will also be used as the environment name:
+
+```bash
+./deploy.sh my-stack-name
+```

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+STACK_NAME=${1:-promo-video}
+
+aws cloudformation deploy \
+  --template-file cloudformation.yaml \
+  --stack-name "$STACK_NAME" \
+  --parameter-overrides EnvironmentName="$STACK_NAME"


### PR DESCRIPTION
## Summary
- add `deploy.sh` script to deploy the CloudFormation template
- document usage of `deploy.sh` in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d08d6e7308326a75d81bd8eb3a1ec