### PR TITLE
Add placeholder promo video generator script and dev plan

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -1,0 +1,20 @@
+# Development Plan: Promo Video Generator
+
+This plan outlines steps to extend the repository so that it contains rudimentary source code for generating a promotional video based on the repository README.
+
+1. **Define Workflow Script**
+   - Implement a Python script (`promo_video_generator.py`) that demonstrates the intended workflow:
+     - Read `README.md` for source text.
+     - Create a placeholder script via a Codex-like stub.
+     - Render slides (stub) and record them with a Playwright-like stub inside Docker.
+     - Synthesize a video via a VEO3-like stub and output the video file name.
+   - Keep all functions self-contained with no external dependencies or credentials.
+
+2. **Documentation Updates**
+   - Update `README.md` to mention the new script and explain that it is a non-functional placeholder illustrating the workflow.
+
+3. **Quality Checks**
+   - Run basic Python compilation to ensure no syntax errors.
+   - Execute the script to show stubbed output.
+
+Future improvements could integrate real API calls, containerisation, and automated testing once credentials and infrastructure are available.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a minimal example for generating a promotional video.
 ## Contents
 - `cloudformation.yaml` – defines AWS infrastructure for storing generated videos.
 - `.microagent/.openhands/microagent/promo-video-agent.md` – instructions for requesting credits and creating the promo video using Codex, VEO3, Docker and Playwright.
+- `promo_video_generator.py` – placeholder Python script illustrating how the workflow could be orchestrated.
 
 No keys or personal data are present in this repository.
 
@@ -29,3 +30,12 @@ Replace `myenv` with the desired value for the `EnvironmentName` parameter. The 
 
 ## About the microagent document
 The microagent markdown file describes a conceptual workflow for generating the promo video. It outlines how tools like VEO3, Docker and Playwright could be used together but does not contain executable code.
+
+## Placeholder promo video script
+`promo_video_generator.py` demonstrates the high-level steps without invoking external services:
+
+```bash
+python promo_video_generator.py
+```
+
+The script reads `README.md`, simulates script generation, stub slide rendering, and stub video synthesis. It is intended for illustration only and does not produce an actual video.

--- a/promo_video_generator.py
+++ b/promo_video_generator.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Placeholder workflow for generating a promo video from README content.
+
+This script demonstrates the intended orchestration without calling external
+services. Functions are stubs to show where Codex, VEO3, Docker and Playwright
+would be integrated.
+"""
+
+from pathlib import Path
+
+
+def read_readme() -> str:
+    """Return the text of README.md."""
+    return Path("README.md").read_text(encoding="utf-8")
+
+
+def generate_script(source_text: str) -> str:
+    """Simulate expanding README content into a dialogue script."""
+    return "Script derived from README:\n" + source_text[:200] + "..."
+
+
+def render_slides(script_text: str) -> str:
+    """Placeholder for Docker/Playwright slide rendering."""
+    print("[stub] Rendering slides with Docker and Playwright...")
+    return "slides"
+
+
+def synthesize_video(script_text: str, slides: str) -> str:
+    """Placeholder for VEO3 video synthesis."""
+    print("[stub] Synthesizing video with VEO3...")
+    return "promo_video.mp4"
+
+
+def main() -> None:
+    source = read_readme()
+    script = generate_script(source)
+    slides = render_slides(script)
+    video_file = synthesize_video(script, slides)
+    print(f"Video generated: {video_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document a development plan outlining steps for a promo video workflow
- add a placeholder Python script that demonstrates reading README content, stub slide rendering, and stub VEO3 synthesis
- update README to reference the new script and how to run it

## Testing
- `python -m py_compile promo_video_generator.py`
- `python promo_video_generator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d0b1507e88326b5aece15aa6bdf23