### PR TITLE
Add site publishing and evaluation automation

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,31 @@
+name: Publish website
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/evaluate-site.yml
+++ b/.github/workflows/evaluate-site.yml
@@ -1,0 +1,32 @@
+name: Evaluate website
+
+on:
+  workflow_run:
+    workflows: ["Publish website"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Evaluate site
+        run: |
+          python evaluate_site.py
+          python generate_codex_prompt.py
+      - name: Upload next steps
+        uses: actions/upload-artifact@v3
+        with:
+          name: next-steps
+          path: devplan.nextsteps.md
+      - name: Upload Codex prompt
+        uses: actions/upload-artifact@v3
+        with:
+          name: codex-prompt
+          path: codex_prompt.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+codex_prompt.txt

--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ python promo_video_generator.py
 ```
 
 The script reads `README.md`, simulates script generation, stub slide rendering, and stub video synthesis. It is intended for illustration only and does not produce an actual video.
+
+## Website publishing and evaluation
+A simple static site lives in the `website/` directory. The workflow in
+`.github/workflows/deploy-site.yml` publishes this directory to GitHub
+Pages whenever changes land on the `main` branch.
+
+After deployment the `evaluate-site` workflow runs. It executes
+`evaluate_site.py` to create `devplan.nextsteps.md` with suggested
+improvements, then `generate_codex_prompt.py` converts those steps into a
+text prompt (`codex_prompt.txt`) suitable for Codex.

--- a/devplan.nextsteps.md
+++ b/devplan.nextsteps.md
@@ -1,0 +1,4 @@
+# Next Steps
+- [ ] Review site layout with Playwright (stub).
+- [ ] Expand README content into full documentation.
+- [ ] Automate video generation pipeline.

--- a/evaluate_site.py
+++ b/evaluate_site.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Stub evaluation of published website using microagents.
+
+This script pretends to analyse the generated website with an
+OpenHands microagent and Playwright. It writes a development plan
+"devplan.nextsteps.md" suggesting future improvements.
+"""
+from pathlib import Path
+
+
+def main() -> None:
+    # In a real implementation, website build artifacts would be
+    # evaluated here. For now we simply create a placeholder file.
+    next_steps = [
+        "# Next Steps",
+        "- [ ] Review site layout with Playwright (stub).",
+        "- [ ] Expand README content into full documentation.",
+        "- [ ] Automate video generation pipeline.",
+    ]
+    # Ensure the markdown file ends with a trailing newline so shell prompts
+    # are not glued to the last line when viewed via `cat`.
+    Path("devplan.nextsteps.md").write_text("\n".join(next_steps) + "\n", encoding="utf-8")
+    print("devplan.nextsteps.md written")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_codex_prompt.py
+++ b/generate_codex_prompt.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Convert devplan.nextsteps.md into a Codex-friendly prompt."""
+from pathlib import Path
+
+
+def main() -> None:
+    steps_path = Path("devplan.nextsteps.md")
+    if not steps_path.exists():
+        raise SystemExit("devplan.nextsteps.md not found; run evaluate_site.py first")
+    steps = steps_path.read_text(encoding="utf-8")
+    prompt = f"Please implement the following next steps:\n\n{steps}\n"
+    Path("codex_prompt.txt").write_text(prompt, encoding="utf-8")
+    print("codex_prompt.txt written")
+
+
+if __name__ == "__main__":
+    main()

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Promo Video Generator</title>
+</head>
+<body>
+  <h1>Promo Video Generator</h1>
+  <p>This site is generated from repository contents.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- publish `website/` to GitHub Pages using a new workflow
- evaluate published site and convert next steps into a Codex prompt
- document website workflow in README

## Testing
- `python evaluate_site.py`
- `python generate_codex_prompt.py`
- `python promo_video_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_688f3a1180f8832699b0cc74c66572d6